### PR TITLE
Fix Ferrum::Network::Response#loaded? for redirect response

### DIFF
--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -362,6 +362,7 @@ module Ferrum
         if params["redirectResponse"]
           previous_exchange = select(request.id)[-2]
           response = Network::Response.new(@page, params)
+          response.loaded = true
           previous_exchange.response = response
         end
 


### PR DESCRIPTION
Mitigates upstream issue https://github.com/rubycdp/ferrum/issues/321

Copying this into the Shopify org from @francisbeaudoin's repo.